### PR TITLE
Create DAO Interfaces and DynamoDAOs

### DIFF
--- a/server/src/main/java/com/codemonkeys/server/authorization/AuthorizationDynamoDAO.kt
+++ b/server/src/main/java/com/codemonkeys/server/authorization/AuthorizationDynamoDAO.kt
@@ -1,0 +1,22 @@
+package com.codemonkeys.server.authorization
+
+import com.codemonkeys.server.core.dao.BaseDynamoDAO
+
+class AuthorizationDynamoDAO : BaseDynamoDAO(), IAuthorizationDAO {
+    override fun deleteAuthToken(authToken: String): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun insertAuthToken(authToken: String, userID: String, groupID: String?): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun getUserIDFromAuthToken(authToken: String): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getGroupIDFromAuthToken(authToken: String): String? {
+        TODO("Not yet implemented")
+    }
+
+}

--- a/server/src/main/java/com/codemonkeys/server/authorization/AuthorizationService.kt
+++ b/server/src/main/java/com/codemonkeys/server/authorization/AuthorizationService.kt
@@ -5,13 +5,13 @@ import com.codemonkeys.server.core.NotAuthorizedException
 class AuthorizationService {
     fun getUserIDFromAuthToken(authToken: String): String {
         // If userID is null, that means the authToken wasn't valid so we should throw an exception.
-        val authorizationDAO = AuthorizationDAO()
+        val authorizationDAO = AuthorizationSqlDAO()
         return authorizationDAO.getUserIDFromAuthToken(authToken) ?: throw NotAuthorizedException()
     }
 
     fun getGroupIDFromAuthToken(authToken: String): String {
         // If groupID is null, that means the authToken wasn't valid so we should throw an exception.
-        val authorizationDAO = AuthorizationDAO()
+        val authorizationDAO = AuthorizationSqlDAO()
         return authorizationDAO.getGroupIDFromAuthToken(authToken) ?: throw NotAuthorizedException()
     }
 }

--- a/server/src/main/java/com/codemonkeys/server/authorization/AuthorizationSqlDAO.kt
+++ b/server/src/main/java/com/codemonkeys/server/authorization/AuthorizationSqlDAO.kt
@@ -1,13 +1,13 @@
 package com.codemonkeys.server.authorization
 
-import com.codemonkeys.server.core.dao.BaseDAO
+import com.codemonkeys.server.core.dao.BaseSqlDAO
 
-class AuthorizationDAO : BaseDAO() {
+class AuthorizationSqlDAO : BaseSqlDAO(), IAuthorizationDAO {
     private val DELETE_AUTHTOKEN_SQL = """
         DELETE FROM AuthToken
             WHERE authToken = ?;
     """
-    fun deleteAuthToken(authToken: String): Boolean {
+    override fun deleteAuthToken(authToken: String): Boolean {
         val connection = this.openConnection()
         val statement = connection.prepareStatement(DELETE_AUTHTOKEN_SQL)
         statement.setString(1, authToken)
@@ -28,7 +28,7 @@ class AuthorizationDAO : BaseDAO() {
             VALUES(?, ?, ?);
     """
 
-    fun insertAuthToken(authToken:String, userID: String, groupID: String?): Boolean {
+    override fun insertAuthToken(authToken:String, userID: String, groupID: String?): Boolean {
         val connection = this.openConnection()
 
         val statement = connection.prepareStatement(INSERT_AUTHTOKEN_SQL)
@@ -53,7 +53,7 @@ class AuthorizationDAO : BaseDAO() {
     """
     // If the authToken belongs to a User, returns the userID of that user.
     // If the authToken belongs to either a Group or nobody, returns null.
-    fun getUserIDFromAuthToken(authToken: String): String? {
+    override fun getUserIDFromAuthToken(authToken: String): String? {
         val connection = this.openConnection()
 
         val statement = connection.prepareStatement(GET_USERID_SQL)
@@ -74,7 +74,7 @@ class AuthorizationDAO : BaseDAO() {
     // If the authToken belongs to a Group, returns the Group's groupID.
     // If the authToken belongs to a User, returns the groupID that the user belongs to.
     // If the authToken belongs to neither, returns null.
-    fun getGroupIDFromAuthToken(authToken: String): String? {
+    override fun getGroupIDFromAuthToken(authToken: String): String? {
         val connection = this.openConnection()
 
         val statement = connection.prepareStatement(GET_GROUPID_SQL)

--- a/server/src/main/java/com/codemonkeys/server/authorization/IAuthorizationDAO.kt
+++ b/server/src/main/java/com/codemonkeys/server/authorization/IAuthorizationDAO.kt
@@ -1,0 +1,11 @@
+package com.codemonkeys.server.authorization
+
+interface IAuthorizationDAO {
+    fun deleteAuthToken(authToken: String): Boolean
+
+    fun insertAuthToken(authToken: String, userID: String, groupID: String?): Boolean
+
+    fun getUserIDFromAuthToken(authToken: String): String?
+
+    fun getGroupIDFromAuthToken(authToken: String): String?
+}

--- a/server/src/main/java/com/codemonkeys/server/clockGroup/ClockGroupDynamoDAO.kt
+++ b/server/src/main/java/com/codemonkeys/server/clockGroup/ClockGroupDynamoDAO.kt
@@ -1,0 +1,38 @@
+package com.codemonkeys.server.clockGroup
+
+import com.codemonkeys.server.core.dao.BaseDynamoDAO
+import com.codemonkeys.shared.clockGroup.ClockGroup
+
+class ClockGroupDynamoDAO : BaseDynamoDAO(), IClockGroupDAO {
+    override fun createNewGroup(singleGroup: ClockGroup) {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateGroupInUser(groupID: String, userID: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getClockGroup(groupID: String): ClockGroup {
+        TODO("Not yet implemented")
+    }
+
+    override fun getGroupIDViaUser(userID: String): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun getUserIDViaUserName(userName: String): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun deleteGroup(groupID: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getGroupIDViaGroupName(groupName: String): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun setAuthTokenTable(authToken: String, groupID: String) {
+        TODO("Not yet implemented")
+    }
+}

--- a/server/src/main/java/com/codemonkeys/server/clockGroup/ClockGroupSqlDAO.kt
+++ b/server/src/main/java/com/codemonkeys/server/clockGroup/ClockGroupSqlDAO.kt
@@ -1,11 +1,11 @@
 package com.codemonkeys.server.clockGroup
-import com.codemonkeys.server.core.dao.BaseDAO
+import com.codemonkeys.server.core.dao.BaseSqlDAO
 import com.codemonkeys.shared.clockGroup.ClockGroup
 
-class ClockGroupDao : BaseDAO() {
+class ClockGroupSqlDAO : BaseSqlDAO(), IClockGroupDAO {
 
     // function that insert a single Group info in the Group table
-    fun createNewGroup(singleGroup: ClockGroup){
+    override fun createNewGroup(singleGroup: ClockGroup){
         val connection = openConnection()
         try {
             super.insertObject(ClockGroup::class.java, connection, "ClockGroup", singleGroup)
@@ -22,7 +22,7 @@ class ClockGroupDao : BaseDAO() {
             SET groupID=?
             WHERE userID=?
         """
-    fun updateGroupInUser(groupID: String, userID: String) {
+    override fun updateGroupInUser(groupID: String, userID: String) {
         val connection = openConnection()
         try{
             val updateStatement = connection.prepareStatement(UPDATE_USER_SQL)
@@ -42,7 +42,7 @@ class ClockGroupDao : BaseDAO() {
         SELECT * FROM ClockGroup
             WHERE groupID=?
         """
-    fun getClockGroup(groupID: String): ClockGroup {
+    override fun getClockGroup(groupID: String): ClockGroup {
         val connection = openConnection()
         try{
             val getStatement = connection.prepareStatement(GET_CLOCK_GROUP_SQL)
@@ -73,7 +73,7 @@ class ClockGroupDao : BaseDAO() {
             FROM User
             WHERE userID=?;
     """
-    fun getGroupIDViaUser(userID: String): String{
+    override fun getGroupIDViaUser(userID: String): String{
         val connection = this.openConnection()
         try {
             val preparedStatement = connection.prepareStatement(GET_GROUP_BY_USER_SQL)
@@ -95,7 +95,7 @@ class ClockGroupDao : BaseDAO() {
             FROM User
             WHERE userName=?;
     """
-    fun getUserIDViaUserName(userName: String): String{
+    override fun getUserIDViaUserName(userName: String): String{
         val connection = this.openConnection()
         try {
             val preparedStatement = connection.prepareStatement(GET_USERID_BY_USERNAME_SQL)
@@ -115,7 +115,7 @@ class ClockGroupDao : BaseDAO() {
         DELETE FROM ClockGroup
         WHERE ClockGroup.groupID=?;
     """
-    fun deleteGroup(groupID: String) {
+    override fun deleteGroup(groupID: String) {
         val connection = this.openConnection()
         try {
             val deleteStatement = connection.prepareStatement(DELETE_GROUP_SQL)
@@ -133,7 +133,7 @@ class ClockGroupDao : BaseDAO() {
             FROM ClockGroup
             WHERE groupName=?;
     """
-    fun getGroupIDViaGroupName(groupName: String): String{
+    override fun getGroupIDViaGroupName(groupName: String): String{
         val connection = this.openConnection()
         try {
             val preparedStatement = connection.prepareStatement(GET_GROUPID_BY_GROUPNAME_SQL)
@@ -155,7 +155,7 @@ class ClockGroupDao : BaseDAO() {
         INSERT INTO AuthToken (authToken, userID, groupID)
         VALUES (?, ?, ?);
         """
-    fun setAuthTokenTable(authToken: String, groupID: String) {
+    override fun setAuthTokenTable(authToken: String, groupID: String) {
         val connection = this.openConnection()
         try {
             val updateStatement = connection.prepareStatement(SET_AUTHTOKEN_SQL)

--- a/server/src/main/java/com/codemonkeys/server/clockGroup/IClockGroupDAO.kt
+++ b/server/src/main/java/com/codemonkeys/server/clockGroup/IClockGroupDAO.kt
@@ -1,0 +1,21 @@
+package com.codemonkeys.server.clockGroup
+
+import com.codemonkeys.shared.clockGroup.ClockGroup
+
+interface IClockGroupDAO {
+    fun createNewGroup(singleGroup: ClockGroup)
+
+    fun updateGroupInUser(groupID: String, userID: String)
+
+    fun getClockGroup(groupID: String): ClockGroup
+
+    fun getGroupIDViaUser(userID: String): String
+
+    fun getUserIDViaUserName(userName: String): String
+
+    fun deleteGroup(groupID: String)
+
+    fun getGroupIDViaGroupName(groupName: String): String
+
+    fun setAuthTokenTable(authToken: String, groupID: String)
+}

--- a/server/src/main/java/com/codemonkeys/server/clockGroup/ServerClockGroupService.kt
+++ b/server/src/main/java/com/codemonkeys/server/clockGroup/ServerClockGroupService.kt
@@ -11,7 +11,7 @@ class ServerClockGroupService : IClockGroupService {
 
     override fun createGroup(authToken: String, groupName: String, groupPassword: String){
 
-        val clockGroupDao = ClockGroupDao()
+        val clockGroupDao = ClockGroupSqlDAO()
         // generate a unique group id for the group, and create clockGroup Object
         val groupID = UUID.randomUUID().toString()
         // create a ClockGroup Object
@@ -28,7 +28,7 @@ class ServerClockGroupService : IClockGroupService {
     }
 
     override fun getGroup(authToken: String, groupPassword: String): ClockGroup {
-        val clockGroupDao = ClockGroupDao()
+        val clockGroupDao = ClockGroupSqlDAO()
         val userID = authorizationService.getUserIDFromAuthToken(authToken)
         val groupID = clockGroupDao.getGroupIDViaUser(userID)
         val clockGroup = clockGroupDao.getClockGroup(groupID)
@@ -39,7 +39,7 @@ class ServerClockGroupService : IClockGroupService {
     }
 
     override fun addMemberToGroup (authToken: String, userNameToAdd: String, password: String) {
-        val clockGroupDao = ClockGroupDao()
+        val clockGroupDao = ClockGroupSqlDAO()
         // get the current User ID
         val userID = authorizationService.getUserIDFromAuthToken(authToken)
         // get the groupID
@@ -58,14 +58,14 @@ class ServerClockGroupService : IClockGroupService {
 
     // more of you remove yourself from the group
     override fun deleteMemberFromGroup (authToken: String) {
-        val clockGroupDao = ClockGroupDao()
+        val clockGroupDao = ClockGroupSqlDAO()
         // get the current User ID
         val userID = authorizationService.getUserIDFromAuthToken(authToken)
         clockGroupDao.updateGroupInUser("", userID)
     }
 
     override fun deleteGroup(authToken: String, password: String) {
-        val clockGroupDao = ClockGroupDao()
+        val clockGroupDao = ClockGroupSqlDAO()
         val userID = authorizationService.getUserIDFromAuthToken(authToken)
         val groupID = clockGroupDao.getGroupIDViaUser(userID)
         val storedPassWord = clockGroupDao.getClockGroup(groupID).groupPassword
@@ -78,7 +78,7 @@ class ServerClockGroupService : IClockGroupService {
     }
 
     override fun loginGroup(groupName: String, groupPassword: String): String {
-        val clockGroupDao = ClockGroupDao()
+        val clockGroupDao = ClockGroupSqlDAO()
         val newAuthToken = UUID.randomUUID().toString()
         val groupId = clockGroupDao.getGroupIDViaGroupName(groupName)
         if (groupId == ""){

--- a/server/src/main/java/com/codemonkeys/server/core/dao/BaseDynamoDAO.kt
+++ b/server/src/main/java/com/codemonkeys/server/core/dao/BaseDynamoDAO.kt
@@ -1,0 +1,4 @@
+package com.codemonkeys.server.core.dao
+
+open class BaseDynamoDAO {
+}

--- a/server/src/main/java/com/codemonkeys/server/core/dao/BaseSqlDAO.kt
+++ b/server/src/main/java/com/codemonkeys/server/core/dao/BaseSqlDAO.kt
@@ -8,7 +8,7 @@ import java.sql.PreparedStatement
 import java.sql.ResultSet
 
 // https://www.mysqltutorial.org/mysql-jdbc-tutorial/
-open class BaseDAO {
+open class BaseSqlDAO {
     // https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/java-rds.html
     protected fun openConnection(): Connection {
         val url = System.getenv("RDS_DB_URL")

--- a/server/src/main/java/com/codemonkeys/server/status/IStatusDAO.kt
+++ b/server/src/main/java/com/codemonkeys/server/status/IStatusDAO.kt
@@ -1,0 +1,9 @@
+package com.codemonkeys.server.status
+
+import com.codemonkeys.shared.status.Status
+
+interface IStatusDAO {
+    fun getStatuses(groupID: String): List<Status>
+
+    fun updateStatuses(groupID: String, updatedStatuses: List<Status>)
+}

--- a/server/src/main/java/com/codemonkeys/server/status/ServerStatusService.kt
+++ b/server/src/main/java/com/codemonkeys/server/status/ServerStatusService.kt
@@ -13,7 +13,7 @@ class ServerStatusService : IStatusService {
         val authService = AuthorizationService()
         val groupID = authService.getGroupIDFromAuthToken(authToken)
 
-        val statusDAO = StatusDAO()
+        val statusDAO = StatusSqlDAO()
         return statusDAO.getStatuses(groupID)
     }
 
@@ -27,7 +27,7 @@ class ServerStatusService : IStatusService {
                 throw NotAuthorizedException()
         }
 
-        val statusDAO = StatusDAO()
+        val statusDAO = StatusSqlDAO()
         statusDAO.updateStatuses(groupID, updatedStatuses)
     }
 }

--- a/server/src/main/java/com/codemonkeys/server/status/StatusDynamoDAO.kt
+++ b/server/src/main/java/com/codemonkeys/server/status/StatusDynamoDAO.kt
@@ -1,0 +1,14 @@
+package com.codemonkeys.server.status
+
+import com.codemonkeys.server.core.dao.BaseDynamoDAO
+import com.codemonkeys.shared.status.Status
+
+class StatusDynamoDAO : BaseDynamoDAO(), IStatusDAO {
+    override fun getStatuses(groupID: String): List<Status> {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateStatuses(groupID: String, updatedStatuses: List<Status>) {
+        TODO("Not yet implemented")
+    }
+}

--- a/server/src/main/java/com/codemonkeys/server/status/StatusSqlDAO.kt
+++ b/server/src/main/java/com/codemonkeys/server/status/StatusSqlDAO.kt
@@ -1,9 +1,9 @@
 package com.codemonkeys.server.status
 
-import com.codemonkeys.server.core.dao.BaseDAO
+import com.codemonkeys.server.core.dao.BaseSqlDAO
 import com.codemonkeys.shared.status.Status
 
-class StatusDAO : BaseDAO() {
+class StatusSqlDAO : BaseSqlDAO(), IStatusDAO {
     // We can include string literals by using triple quotes. It makes our SQL statements easy to read.
     // https://www.journaldev.com/17318/kotlin-string#raw-strings-8211-multiline-string
     private val GET_STATUSES_SQL =
@@ -15,7 +15,7 @@ class StatusDAO : BaseDAO() {
         """
 
     // https://www.mysqltutorial.org/mysql-jdbc-tutorial/
-    fun getStatuses(groupID: String): List<Status> {
+    override fun getStatuses(groupID: String): List<Status> {
         val connection = this.openConnection()
         try {
             val statement = connection.prepareStatement(GET_STATUSES_SQL)
@@ -35,7 +35,7 @@ class StatusDAO : BaseDAO() {
             FROM Status
             WHERE groupID = ?;
     """
-    fun updateStatuses(groupID: String, updatedStatuses: List<Status>){
+    override fun updateStatuses(groupID: String, updatedStatuses: List<Status>){
         val connection = this.openConnection()
         try {
             val deleteStatement = connection.prepareStatement(DELETE_GROUP_STATUSES_SQL)

--- a/server/src/main/java/com/codemonkeys/server/user/IUserDAO.kt
+++ b/server/src/main/java/com/codemonkeys/server/user/IUserDAO.kt
@@ -1,0 +1,23 @@
+package com.codemonkeys.server.user
+
+import com.codemonkeys.shared.user.User
+import com.codemonkeys.shared.user.requests.CreateUserRequest
+import com.codemonkeys.shared.user.requests.LoginUserRequest
+import com.codemonkeys.shared.user.requests.LogoutUserRequest
+import com.codemonkeys.shared.user.requests.UpdateUserRequest
+import com.codemonkeys.shared.user.responses.CreateUserResponse
+import com.codemonkeys.shared.user.responses.LoginUserResponse
+import com.codemonkeys.shared.user.responses.LogoutUserResponse
+import com.codemonkeys.shared.user.responses.UpdateUserResponse
+
+interface IUserDAO {
+    fun createUser(request: CreateUserRequest): CreateUserResponse
+
+    fun getUser(userID: String): User?
+
+    fun loginUser(request: LoginUserRequest): LoginUserResponse
+
+    fun logoutUser(request: LogoutUserRequest): LogoutUserResponse
+
+    fun updateUser(request: UpdateUserRequest): UpdateUserResponse
+}

--- a/server/src/main/java/com/codemonkeys/server/user/UserDynamoDAO.kt
+++ b/server/src/main/java/com/codemonkeys/server/user/UserDynamoDAO.kt
@@ -1,6 +1,7 @@
 package com.codemonkeys.server.user
 
-import com.codemonkeys.shared.user.IUserService
+import com.codemonkeys.server.core.dao.BaseDynamoDAO
+import com.codemonkeys.shared.user.User
 import com.codemonkeys.shared.user.requests.CreateUserRequest
 import com.codemonkeys.shared.user.requests.LoginUserRequest
 import com.codemonkeys.shared.user.requests.LogoutUserRequest
@@ -10,24 +11,24 @@ import com.codemonkeys.shared.user.responses.LoginUserResponse
 import com.codemonkeys.shared.user.responses.LogoutUserResponse
 import com.codemonkeys.shared.user.responses.UpdateUserResponse
 
-class ServerUserService : IUserService {
+class UserDynamoDAO : BaseDynamoDAO(), IUserDAO {
     override fun createUser(request: CreateUserRequest): CreateUserResponse {
-        val userDAO = UserSqlDAO()
-        return userDAO.createUser(request)
+        TODO("Not yet implemented")
+    }
+
+    override fun getUser(userID: String): User? {
+        TODO("Not yet implemented")
     }
 
     override fun loginUser(request: LoginUserRequest): LoginUserResponse {
-        val userDAO = UserSqlDAO()
-        return userDAO.loginUser(request)
+        TODO("Not yet implemented")
     }
 
     override fun logoutUser(request: LogoutUserRequest): LogoutUserResponse {
-        val userDAO = UserSqlDAO()
-        return userDAO.logoutUser(request)
+        TODO("Not yet implemented")
     }
 
     override fun updateUser(request: UpdateUserRequest): UpdateUserResponse {
-        val userDAO = UserSqlDAO()
-        return userDAO.updateUser(request)
+        TODO("Not yet implemented")
     }
 }

--- a/server/src/main/java/com/codemonkeys/server/whereabout/IWhereaboutDAO.kt
+++ b/server/src/main/java/com/codemonkeys/server/whereabout/IWhereaboutDAO.kt
@@ -1,0 +1,9 @@
+package com.codemonkeys.server.whereabout
+
+import com.codemonkeys.shared.whereabout.Whereabout
+
+interface IWhereaboutDAO {
+    fun getWhereabouts(groupID: String): List<Whereabout>
+
+    fun updateUserWhereabout(userID: String, currentZoneID: String?)
+}

--- a/server/src/main/java/com/codemonkeys/server/whereabout/WhereaboutDynamoDAO.kt
+++ b/server/src/main/java/com/codemonkeys/server/whereabout/WhereaboutDynamoDAO.kt
@@ -1,0 +1,14 @@
+package com.codemonkeys.server.whereabout
+
+import com.codemonkeys.server.core.dao.BaseDynamoDAO
+import com.codemonkeys.shared.whereabout.Whereabout
+
+class WhereaboutDynamoDAO : BaseDynamoDAO(), IWhereaboutDAO {
+    override fun getWhereabouts(groupID: String): List<Whereabout> {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateUserWhereabout(userID: String, currentZoneID: String?) {
+        TODO("Not yet implemented")
+    }
+}

--- a/server/src/main/java/com/codemonkeys/server/whereabout/WhereaboutService.kt
+++ b/server/src/main/java/com/codemonkeys/server/whereabout/WhereaboutService.kt
@@ -1,8 +1,6 @@
 package com.codemonkeys.server.whereabout
 
 import com.codemonkeys.server.authorization.AuthorizationService
-import com.codemonkeys.server.core.NotAuthorizedException
-import com.codemonkeys.server.zone.ZoneDAO
 import com.codemonkeys.shared.whereabout.IWhereaboutService
 import com.codemonkeys.shared.whereabout.Whereabout
 
@@ -12,7 +10,7 @@ class WhereaboutService : IWhereaboutService {
         val authService = AuthorizationService()
         val groupID = authService.getGroupIDFromAuthToken(authToken)
 
-        val whereaboutDAO = WhereaboutDAO()
+        val whereaboutDAO = WhereaboutSqlDAO()
         return whereaboutDAO.getWhereabouts(groupID)
     }
 
@@ -30,7 +28,7 @@ class WhereaboutService : IWhereaboutService {
 //            }
 //        }
 
-        val whereaboutDAO = WhereaboutDAO()
+        val whereaboutDAO = WhereaboutSqlDAO()
         whereaboutDAO.updateUserWhereabout(userID, currentZoneID)
     }
 }

--- a/server/src/main/java/com/codemonkeys/server/whereabout/WhereaboutSqlDAO.kt
+++ b/server/src/main/java/com/codemonkeys/server/whereabout/WhereaboutSqlDAO.kt
@@ -1,9 +1,9 @@
 package com.codemonkeys.server.whereabout
 
-import com.codemonkeys.server.core.dao.BaseDAO
+import com.codemonkeys.server.core.dao.BaseSqlDAO
 import com.codemonkeys.shared.whereabout.Whereabout
 
-class WhereaboutDAO: BaseDAO() {
+class WhereaboutSqlDAO: BaseSqlDAO(), IWhereaboutDAO {
     private val GET_WHEREABOUTS_SQL = """
         SELECT userID, username, clockHandIndex, z.statusID AS statusID, IFNULL(s.clockHandAngle, 0) AS clockHandAngle
             FROM User u
@@ -11,7 +11,7 @@ class WhereaboutDAO: BaseDAO() {
                 LEFT JOIN Status s ON z.statusID = s.statusID
         WHERE u.groupID = ?;
     """
-    fun getWhereabouts(groupID: String): List<Whereabout> {
+    override fun getWhereabouts(groupID: String): List<Whereabout> {
         val connection = this.openConnection()
         try {
             val preparedStatement = connection.prepareStatement(GET_WHEREABOUTS_SQL)
@@ -29,7 +29,7 @@ class WhereaboutDAO: BaseDAO() {
             SET currentZoneID = ?
             WHERE userID = ?;
     """
-    fun updateUserWhereabout(userID: String, currentZoneID: String?) {
+    override fun updateUserWhereabout(userID: String, currentZoneID: String?) {
         val connection = this.openConnection()
         try {
             val preparedStatement = connection.prepareStatement(SET_WHEREABOUT_SQL)

--- a/server/src/main/java/com/codemonkeys/server/zone/IZoneDAO.kt
+++ b/server/src/main/java/com/codemonkeys/server/zone/IZoneDAO.kt
@@ -1,0 +1,9 @@
+package com.codemonkeys.server.zone
+
+import com.codemonkeys.shared.zone.Zone
+
+interface IZoneDAO {
+    fun getZones(groupID: String): List<Zone>
+
+    fun updateZones(groupID: String, updatedZones: List<Zone>)
+}

--- a/server/src/main/java/com/codemonkeys/server/zone/ServerZoneService.kt
+++ b/server/src/main/java/com/codemonkeys/server/zone/ServerZoneService.kt
@@ -11,7 +11,7 @@ class ServerZoneService : IZoneService {
         val authService = AuthorizationService()
         val groupID = authService.getGroupIDFromAuthToken(authToken)
 
-        val zoneDAO = ZoneDAO()
+        val zoneDAO = ZoneSqlDAO()
         return zoneDAO.getZones(groupID)
     }
 
@@ -28,7 +28,7 @@ class ServerZoneService : IZoneService {
             }
         }
 
-        val zoneDAO = ZoneDAO()
+        val zoneDAO = ZoneSqlDAO()
         zoneDAO.updateZones(groupID, updatedZones)
     }
 }

--- a/server/src/main/java/com/codemonkeys/server/zone/ZoneDynamoDAO.kt
+++ b/server/src/main/java/com/codemonkeys/server/zone/ZoneDynamoDAO.kt
@@ -1,0 +1,15 @@
+package com.codemonkeys.server.zone
+
+import com.codemonkeys.server.core.dao.BaseDynamoDAO
+import com.codemonkeys.shared.zone.Zone
+
+class ZoneDynamoDAO : BaseDynamoDAO(), IZoneDAO {
+    override fun getZones(groupID: String): List<Zone> {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateZones(groupID: String, updatedZones: List<Zone>) {
+        TODO("Not yet implemented")
+    }
+
+}

--- a/server/src/main/java/com/codemonkeys/server/zone/ZoneSqlDAO.kt
+++ b/server/src/main/java/com/codemonkeys/server/zone/ZoneSqlDAO.kt
@@ -1,9 +1,9 @@
 package com.codemonkeys.server.zone
 
-import com.codemonkeys.server.core.dao.BaseDAO
+import com.codemonkeys.server.core.dao.BaseSqlDAO
 import com.codemonkeys.shared.zone.Zone
 
-class ZoneDAO : BaseDAO() {
+class ZoneSqlDAO : BaseSqlDAO(), IZoneDAO {
 
     private var GET_ZONES_SQL = """
         SELECT *
@@ -13,7 +13,7 @@ class ZoneDAO : BaseDAO() {
             ORDER BY zoneID;
     """
 
-    fun getZones(groupID: String): List<Zone> {
+    override fun getZones(groupID: String): List<Zone> {
         val connection = openConnection()
         try {
             val statement = connection.prepareStatement(GET_ZONES_SQL)
@@ -34,7 +34,7 @@ class ZoneDAO : BaseDAO() {
             WHERE s.groupID = ?;
     """
 
-    fun updateZones(groupID: String, updatedZones: List<Zone>) {
+    override fun updateZones(groupID: String, updatedZones: List<Zone>) {
         val connection = this.openConnection()
 
         try {
@@ -52,24 +52,4 @@ class ZoneDAO : BaseDAO() {
             this.closeConnection(connection)
         }
     }
-
-//    private val GET_ZONES_GROUP_ID_SQL = """
-//        SELECT s.groupID
-//            FROM Zone z
-//                JOIN Status s ON s.statusID = z.statusID
-//            WHERE z.zoneID IN ?;
-//    """
-//
-//    fun getZonesGroupID(zoneIDs: List<String>): List<String> {
-//        val connection = this.openConnection()
-//        try {
-//            val preparedStatement = connection.prepareStatement(GET_ZONES_GROUP_ID_SQL)
-//            preparedStatement.setObject(1, zoneIDs)
-//            val resultSet = preparedStatement.executeQuery()
-//            return this.getSimpleQueryResults<String>(resultSet)
-//        }
-//        finally {
-//            connection.close()
-//        }
-//    }
 }

--- a/server/src/test/java/com/codemonkeys/server/DatabasePreparer.kt
+++ b/server/src/test/java/com/codemonkeys/server/DatabasePreparer.kt
@@ -1,8 +1,8 @@
 package com.codemonkeys.server
 
-import com.codemonkeys.server.core.dao.BaseDAO
+import com.codemonkeys.server.core.dao.BaseSqlDAO
 
-class DatabasePreparer: BaseDAO() {
+class DatabasePreparer: BaseSqlDAO() {
     // https://stackoverflow.com/a/42740416/6634972
     fun prepareDatabase() {
         val createDatabaseSQL = DatabasePreparer::class.java.getResource("/DatabaseSQL/create_database.sql").readText()

--- a/server/src/test/java/com/codemonkeys/server/authorization/TestAuthorizationDAO.kt
+++ b/server/src/test/java/com/codemonkeys/server/authorization/TestAuthorizationDAO.kt
@@ -7,7 +7,7 @@ import org.junit.Assert.*
 class TestAuthorizationDAO: BaseTest() {
     @Test
     fun testAuthorizeUserID() {
-        val authorizationDAO = AuthorizationDAO()
+        val authorizationDAO = AuthorizationSqlDAO()
         val userID = authorizationDAO.getUserIDFromAuthToken("e00f1c88-1d5b-4d32-be07-1018f39a26b2")
         val expectedUserID = "3ea0f56f-7864-4d49-a5ed-5f741a7969c8"
         assertEquals("Should find the authToken and return correct userID", expectedUserID, userID)
@@ -21,7 +21,7 @@ class TestAuthorizationDAO: BaseTest() {
 
     @Test
     fun testAuthorizeGroupID() {
-        val authorizationDAO = AuthorizationDAO()
+        val authorizationDAO = AuthorizationSqlDAO()
         // Group's AuthToken
         val groupID = authorizationDAO.getGroupIDFromAuthToken("7af562ed-46bd-429b-8bcd-2d85e76d9a10")
         val expectedGroupID = "2bc8f348-fce4-4df6-9795-deff8e721c7a"

--- a/server/src/test/java/com/codemonkeys/server/clockGroup/GroupDAOTests.kt
+++ b/server/src/test/java/com/codemonkeys/server/clockGroup/GroupDAOTests.kt
@@ -9,7 +9,7 @@ import org.junit.Test
 
 
 class GroupDAOTests: BaseTest() {
-    var clockGroupDao = ClockGroupDao()
+    var clockGroupDao = ClockGroupSqlDAO()
     // tests for getClockGroup function
     @Test
     fun getGroup_Success_Test(){

--- a/server/src/test/java/com/codemonkeys/server/clockGroup/GroupServiceTests.kt
+++ b/server/src/test/java/com/codemonkeys/server/clockGroup/GroupServiceTests.kt
@@ -9,7 +9,7 @@ import org.junit.Test
 
 class GroupServiceTests: BaseTest() {
     val groupService = ServerClockGroupService()
-    val clockGroupDao = ClockGroupDao()
+    val clockGroupDao = ClockGroupSqlDAO()
     val authorizationService = AuthorizationService()
 
     // tests for getGroup function

--- a/server/src/test/java/com/codemonkeys/server/status/TestStatusDAO.kt
+++ b/server/src/test/java/com/codemonkeys/server/status/TestStatusDAO.kt
@@ -9,7 +9,7 @@ import org.junit.Assert.*
 class TestStatusDAO: BaseTest() {
     @Test
     fun testGetStatuses() {
-        val statusDAO = StatusDAO()
+        val statusDAO = StatusSqlDAO()
         val group2Statuses = statusDAO.getStatuses(GroupTestResources.GROUP_2_ID)
         assertEquals("Should only return statuses belonging to group", StatusTestResources.GROUP_2_STATUSES, group2Statuses)
 
@@ -20,7 +20,7 @@ class TestStatusDAO: BaseTest() {
 
     @Test
     fun testUpdateStatuses() {
-        val statusDAO = StatusDAO()
+        val statusDAO = StatusSqlDAO()
         statusDAO.updateStatuses(GroupTestResources.GROUP_2_ID, StatusTestResources.GROUP_2_UPDATED_STATUSES)
         val group2UpdatedStatuses = statusDAO.getStatuses(GroupTestResources.GROUP_2_ID)
         assertEquals("The statuses we get back for this group should be the same as we put in. No more, no less.", StatusTestResources.GROUP_2_UPDATED_STATUSES.sortedBy { it.statusID }, group2UpdatedStatuses)

--- a/server/src/test/java/com/codemonkeys/server/status/TestUpdateStatusesHandler.kt
+++ b/server/src/test/java/com/codemonkeys/server/status/TestUpdateStatusesHandler.kt
@@ -13,7 +13,7 @@ class TestUpdateStatusesHandler : BaseTest() {
 
     @Test
     fun testUpdateStatusesHandler() {
-        val statusDAO = StatusDAO()
+        val statusDAO = StatusSqlDAO()
         val updateStatusesHandler = UpdateStatusesHandler()
 
         val invalidGroupIDResponse = updateStatusesHandler.handleRequest(StatusTestResources.GROUP_2_INVALID_STATUSES_REQUEST, null)

--- a/server/src/test/java/com/codemonkeys/server/user/TestUserDAO.kt
+++ b/server/src/test/java/com/codemonkeys/server/user/TestUserDAO.kt
@@ -13,7 +13,7 @@ class TestUserDAO : BaseTest() {
 
     @Test
     fun testCreateUser() {
-        val userDAO = UserDAO()
+        val userDAO = UserSqlDAO()
         val request =
             CreateUserRequest(UserTestResources.GROUP_1_NEW_USER_1)
         val response = userDAO.createUser(request)
@@ -38,7 +38,7 @@ class TestUserDAO : BaseTest() {
 
     @Test
     fun testUpdateUser() {
-        val userDAO = UserDAO()
+        val userDAO = UserSqlDAO()
         val request = UpdateUserRequest(
             AuthorizationTestResources.GROUP_1_USER_AUTHTOKEN,
             UserTestResources.GROUP_1_USER_1_PASSWORD,
@@ -62,7 +62,7 @@ class TestUserDAO : BaseTest() {
 
     @Test
     fun testLoginUser() {
-        val userDAO = UserDAO()
+        val userDAO = UserSqlDAO()
         val request = LoginUserRequest(
             UserTestResources.GROUP_1_USER_1_USERNAME,
             UserTestResources.GROUP_1_USER_1_PASSWORD
@@ -96,7 +96,7 @@ class TestUserDAO : BaseTest() {
 
     @Test
     fun testLogoutUser() {
-        val userDAO = UserDAO()
+        val userDAO = UserSqlDAO()
         val request =
             LogoutUserRequest(AuthorizationTestResources.GROUP_1_USER_AUTHTOKEN)
         val response = userDAO.logoutUser(request)

--- a/server/src/test/java/com/codemonkeys/server/whereabout/TestWhereaboutDAO.kt
+++ b/server/src/test/java/com/codemonkeys/server/whereabout/TestWhereaboutDAO.kt
@@ -4,7 +4,7 @@ import com.codemonkeys.server.BaseTest
 import com.codemonkeys.server.clockGroup.GroupTestResources
 import org.junit.Test
 import org.junit.Assert.*
-import com.codemonkeys.server.user.UserDAO
+import com.codemonkeys.server.user.UserSqlDAO
 import com.codemonkeys.server.user.UserTestResources
 import com.codemonkeys.shared.whereabout.Whereabout
 
@@ -12,7 +12,7 @@ class TestWhereaboutDAO: BaseTest() {
 
     @Test
     fun testGetWhereabouts() {
-        val whereaboutDAO = WhereaboutDAO()
+        val whereaboutDAO = WhereaboutSqlDAO()
         val group1Whereabouts = whereaboutDAO.getWhereabouts(GroupTestResources.GROUP_1_ID)
         assertEquals("Should return the whereabouts for all users in this group", WhereaboutTestResources.GROUP_1_WHEREABOUTS, group1Whereabouts)
 
@@ -25,8 +25,8 @@ class TestWhereaboutDAO: BaseTest() {
 
     @Test
     fun testUpdateUserWhereabout() {
-        val whereaboutDAO = WhereaboutDAO()
-        val userDAO = UserDAO()
+        val whereaboutDAO = WhereaboutSqlDAO()
+        val userDAO = UserSqlDAO()
         whereaboutDAO.updateUserWhereabout(UserTestResources.GROUP_1_USER_1_ID, WhereaboutTestResources.GROUP_1_ZONE_3_ID)
         val user1 = userDAO.getUser(UserTestResources.GROUP_1_USER_1_ID)
         assertEquals("User's current com.codemonkeys.server.zone should be changed", WhereaboutTestResources.GROUP_1_ZONE_3_ID, user1?.currentZoneID)

--- a/server/src/test/java/com/codemonkeys/server/zone/TestUpdateZonesHandler.kt
+++ b/server/src/test/java/com/codemonkeys/server/zone/TestUpdateZonesHandler.kt
@@ -13,7 +13,7 @@ class TestUpdateZonesHandler : BaseTest() {
 
     @Test
     fun testUpdateZones() {
-        val zoneDAO = ZoneDAO()
+        val zoneDAO = ZoneSqlDAO()
         val updateZonesHandler = UpdateZonesHandler()
 
         val invalidGroupIDResponse =

--- a/server/src/test/java/com/codemonkeys/server/zone/TestZoneDAO.kt
+++ b/server/src/test/java/com/codemonkeys/server/zone/TestZoneDAO.kt
@@ -10,7 +10,7 @@ class TestZoneDAO : BaseTest() {
 
     @Test
     fun testGetZones() {
-        val zoneDAO = ZoneDAO()
+        val zoneDAO = ZoneSqlDAO()
 
         val group1Zones = zoneDAO.getZones(GroupTestResources.GROUP_1_ID)
         assertEquals("Should get zones from just this group", ZoneTestResources.GROUP_1_ZONES, group1Zones)
@@ -26,7 +26,7 @@ class TestZoneDAO : BaseTest() {
 
     @Test
     fun testUpdateZones() {
-        val zoneDAO = ZoneDAO()
+        val zoneDAO = ZoneSqlDAO()
 
         zoneDAO.updateZones(GroupTestResources.GROUP_2_ID, ZoneTestResources.GROUP_2_UPDATED_ZONES)
         val group2UpdatedZones = zoneDAO.getZones(GroupTestResources.GROUP_2_ID)


### PR DESCRIPTION
* Created an interface for each DAO. Ex: IStatusDAO.
* Renamed each existing DAO to specify SQL. Ex: StatusSqlDAO.
* Added interfaces to existing DAOs. Ex: class StatusSqlDAO : IStatusDAO
* Created empty DynamoDAOs for each DAO. Ex: StatusDynamoDAO.
* Each DynamoDAO inherits from interface and BaseDynamoDAO. Ex:
  class StatusDynamoDAO : BaseDynamoDAO(), IStatusDAO

* We will need to fill in the method bodies on the DynamoDAOs using the
  code example from Alec.
* We will need to update the references from SqlDAOs to DynamoDAOs in
  our Services. Perhaps we should've used dependency injection?